### PR TITLE
Fix bug calculating scroll position when unloading elements

### DIFF
--- a/ScrollPagination.js
+++ b/ScrollPagination.js
@@ -179,7 +179,7 @@ var ScrollPagination = window.ScrollPagination = React.createClass({
 		var pages = this.__pages;
 		unloadedPageIdsTop.forEach(function (pageId) {
 			var height = pages[pageId].height;
-			offset += height;
+			offset -= height;
 			delete pages[pageId];
 		});
 		newPageIdsTop.forEach(function (pageId) {


### PR DESCRIPTION
Great library. Do you guys use this in production? Seems like you would have caught this one... scroll position was calculated wrong so the page jerked around when unloading elements.